### PR TITLE
Favorite Countries Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
-## 0.0.1
+## 1.1.0
+- Added `Greenland` as a selectable country.
+- Implemented `favoriteCountries` parameter in `WorldPickerIcon` for displaying favorite countries.
+- Added support for DraggableScrollableSheet in country selection.
+- Implemented `scrollController` parameter in the WorldPicker widget for integration with draggable bottom sheet.
+- Visual separator between favorite countries and other countries in the picker list.
+- Structural fixes to ensure smooth scrolling and integration with expandable modal.
 
-- Initial release with empty setup to reserve package name.
+## 1.0.0
+- Added `PhoneNumberField` widget for phone number input with country selection.
+- Implemented `WorldPickerPhoneNumberTextInputFormatter` for phone number formatting based on selected country.
+- Enhanced `WorldPickerIcon` to support phone number validation.
+- Updated `pubspec.yaml` with new versioning and dependencies.
 
-## 0.0.1+2
-- Updated `pubspec.yaml` with repository, issue tracker, and documentation links.
+## 0.1.1+5
+- Fixed typos and improved clarity in the documentation introduced in version 0.1.0+5.
+
+## 0.1.0+5
+- Updated documentation to include new features and usage examples.
+
+## 0.1.0+4
+- Updated documentation to reflect changes in API methods.
 
 ## 0.1.0+3
 - Added `WorldPickerIcon` widget for country selection with customizable display options for ISO code, name, and currency
@@ -12,17 +28,9 @@
 - Added comprehensive API reference in README.
 - Enhanced README with comprehensive package details, features, and usage examples.
 
-## 0.1.0+4
-- Updated documentation to reflect changes in API methods.
+## 0.0.1+2
+- Updated `pubspec.yaml` with repository, issue tracker, and documentation links.
 
-## 0.1.0+5
-- Updated documentation to include new features and usage examples.
+## 0.0.1
 
-## 0.1.1+5
-- Fixed typos and improved clarity in the documentation introduced in version 0.1.0+5.
-
-## 1.0.0
-- Added `PhoneNumberField` widget for phone number input with country selection.
-- Implemented `WorldPickerPhoneNumberTextInputFormatter` for phone number formatting based on selected country.
-- Enhanced `WorldPickerIcon` to support phone number validation.
-- Updated `pubspec.yaml` with new versioning and dependencies.
+- Initial release with empty setup to reserve package name.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ WorldPickerIcon(
     placeholder: 'Search countries...',
     showCurrencyCode: true,
     showDialCode: true,
+    favoriteCountries: ['US', 'BR', 'IN'],
   ),
 )
 ```
@@ -120,6 +121,7 @@ Configuration options for customizing the country picker dialog.
 | `showIsoCode`     | `bool`                  | Show ISO codes in the country list                         | `true`  |
 | `showDialCode`    | `bool`                  | Show dial codes in the country list                        | `false` |
 | `inputDecoration` | `InputDecoration?`      | Custom decoration for the search input field               | `null`  |
+| `favoriteCountries` | `List<String>?`       | List of ISO codes for favorite countries to show first     | `null`  |
 
 ### Country Model
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,6 +68,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                     prefixIcon: Icon(Icons.search),
                   ),
+                  favoriteCountries: ['US', 'BR', 'FR', 'IN'],
                 ),
               ),
               const SizedBox(height: 20),

--- a/lib/data/north_america_countries.dart
+++ b/lib/data/north_america_countries.dart
@@ -104,5 +104,20 @@ List<Country> northAmericaCountries() {
       timezones: ['America/Santo_Domingo'],
       flagAssetPath: 'packages/world_picker/assets/flags/DO.svg',
     ),
+    Country(
+      isoCode: 'GL',
+      name: 'Greenland',
+      continent: continent,
+      languages: [
+        Language(code: 'kl', name: 'Greenlandic', nativeName: 'Kalaallisut'),
+        Language(code: 'da', name: 'Danish', nativeName: 'Dansk')
+      ],
+      currencies: [Currency(code: 'DKK', name: 'Danish Krone', symbol: 'kr')],
+      dialCode: '+299',
+      phonePattern: r'^\+299\d{6}$',
+      zipCodePattern: r'^39\d{2}$',
+      timezones: ['America/Godthab'],
+      flagAssetPath: 'packages/world_picker/assets/flags/GL.svg',
+    ),
   ];
 }

--- a/lib/services/world_picker_service.dart
+++ b/lib/services/world_picker_service.dart
@@ -69,6 +69,24 @@ class WorldPickerService {
     }
   }
 
+  /// Finds countries by a list of ISO codes.
+  ///
+  /// This method retrieves all countries whose ISO codes match any
+  /// of the provided codes, ignoring case.
+  /// /// [isoCodes] A list of ISO 3166-1 alpha-2 codes (e.g., ['BR', 'US']).
+  /// /// Returns a [List<Country>] containing all matching countries.
+  /// /// Example:
+  /// ```dart
+  /// List<Country> selectedCountries = WorldPickerService.fromIsoCodes(['BR', 'US']);
+  /// // Returns: Brazil, United States
+  /// ```
+  static List<Country> fromIsoCodes(List<String> isoCodes) {
+    final countries = loadCountries();
+    return countries
+        .where((country) => isoCodes.contains(country.isoCode.toUpperCase()))
+        .toList();
+  }
+
   /// Retrieves all countries within a specific continent.
   ///
   /// The search is case-insensitive and uses continent codes:

--- a/lib/widgets/world_picker_icon.dart
+++ b/lib/widgets/world_picker_icon.dart
@@ -147,13 +147,34 @@ class WorldPickerIcon extends StatelessWidget {
       context: context,
       showDragHandle: true,
       backgroundColor: Colors.white,
+      isDismissible: true,
+      enableDrag: true,
+      isScrollControlled: true,
+      elevation: 8.0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(12.0),
+        ),
+      ),
       builder: (context) {
-        return WorldPicker(
-            key: Key('world_picker'),
-            countries: WorldPickerService.countries,
-            size: size,
-            onSelect: onSelect,
-            options: options);
+        return DraggableScrollableSheet(
+          expand: false,
+          snap: true,
+          initialChildSize: 0.7,
+          minChildSize: 0.4,
+          maxChildSize: 0.95,
+          builder: (context, scrollController) {
+            return WorldPicker(
+              key: Key('world_picker'),
+              countries: WorldPickerService.countries,
+              size: size,
+              onSelect: onSelect,
+              options: options,
+              scrollController: scrollController,
+              // Adiciona o scrollController para permitir o arrasto
+            );
+          },
+        );
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: world_picker
 description: Country selector and metadata provider with flags, currency, and more.
-version: 1.0.0
+version: 1.1.0
 
 homepage: https://github.com/williamsimionatto/world_picker
 repository: https://github.com/williamsimionatto/world_picker


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `world_picker` package, including support for favorite countries, integration with `DraggableScrollableSheet`, and the addition of Greenland as a selectable country. It also includes structural improvements to the picker widget and updates to documentation and versioning.

### New Features and Enhancements:
- **Favorite Countries Support:**
  * Added a `favoriteCountries` parameter to the `WorldPicker` widget, allowing users to display a list of favorite countries at the top of the picker. (`[[1]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccR25-R27)`, `[[2]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccR37)`, `[[3]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15R71)`, `[[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103)`, `[[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124)`)
  * Updated the picker logic to visually separate favorite countries from others with a divider. (`[[1]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccL107-R175)`, `[[2]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccL169-L174)`)

- **Integration with DraggableScrollableSheet:**
  * Introduced a `scrollController` parameter in the `WorldPicker` widget for seamless integration with `DraggableScrollableSheet`. (`[[1]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccR47-R49)`, `[[2]](diffhunk://#diff-f72f47bdb0e6cffef239e264c863fe726cd09b4e1bc6195d15558558e23ac82cR150-R177)`)
  * Enhanced the `WorldPickerIcon` widget to support draggable and expandable bottom sheets. (`[lib/widgets/world_picker_icon.dartR150-R177](diffhunk://#diff-f72f47bdb0e6cffef239e264c863fe726cd09b4e1bc6195d15558558e23ac82cR150-R177)`)

- **New Country Addition:**
  * Added Greenland (`GL`) to the list of selectable countries, including its metadata such as languages, currency, and dialing code. (`[lib/data/north_america_countries.dartR107-R121](diffhunk://#diff-2b707d796d1af391789e59735f4a0a1480781bf7199dd8f90cde132b0f42c923R107-R121)`)

### Structural and Documentation Updates:
- **Structural Improvements:**
  * Refactored the picker widget to split countries into favorite and other categories for better organization. (`[[1]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccR75-R117)`, `[[2]](diffhunk://#diff-e638ecafc465a992f71272e01c84ed024af62025e8d3e2328c51547f4cb4abccL107-R175)`)
  * Added a new utility method `fromIsoCodes` in `WorldPickerService` to retrieve countries by ISO codes. (`[lib/services/world_picker_service.dartR72-R89](diffhunk://#diff-d82442f7348b340b2615241a9750a6f5035d72a613562f600c2ef2b891706f8cR72-R89)`)

- **Documentation and Versioning:**
  * Updated the `README.md` to include details about the `favoriteCountries` parameter and its usage. (`[README.mdR124](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R124)`)
  * Updated the `CHANGELOG.md` to reflect the new features and enhancements. (`[[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R22)`, `[[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL15-R36)`)
  * Bumped the package version to `1.1.0` in `pubspec.yaml`. (`[pubspec.yamlL3-R3](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3)`)