### PR TITLE
feat: Add Antarctica to the list of selectable countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2
+- Added Antarctica to the list of selectable countries.
+
 ## 1.2.1
 - Fixed issue with `CurrencyWorldPickerIcon` not applying options correctly.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -159,10 +159,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -244,10 +244,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -310,7 +310,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.4"
+    version: "1.2.1"
   xml:
     dependency: transitive
     description:

--- a/lib/data/all_countries.dart
+++ b/lib/data/all_countries.dart
@@ -11,5 +11,23 @@ List<Country> allCountries() {
     ...caribbeanCountries(),
     ...oceaniaCountries(),
     ...southAmericaCountries(),
+    Country(
+      isoCode: 'AQ',
+      name: 'Antarctica',
+      continent: Continent(code: 'AQ', name: 'Antarctica'),
+      languages: [
+        Language(code: 'en', name: 'English', nativeName: 'English'),
+        Language(code: 'es', name: 'Spanish', nativeName: 'Español'),
+        Language(code: 'ru', name: 'Russian', nativeName: 'Русский'),
+      ],
+      currencies: [
+        Currency(code: 'USD', name: 'US Dollar', symbol: '\$'),
+      ],
+      dialCode: '',
+      phonePattern: r'^\d*$',
+      zipCodePattern: r'^\d*$',
+      timezones: const ['UTC'],
+      flagAssetPath: 'packages/world_picker/assets/flags/AQ.svg',
+    ),
   ];
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,10 +74,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: world_picker
 description: Country selector and metadata provider with flags, currency, and more.
-version: 1.2.1
+
+version: 1.2.2
 
 homepage: https://github.com/williamsimionatto/world_picker
 repository: https://github.com/williamsimionatto/world_picker


### PR DESCRIPTION
This pull request introduces a new selectable country, Antarctica, to the country picker library and updates the package version to reflect this addition.

New country support:

* Added Antarctica (`AQ`) to the `allCountries` list in `lib/data/all_countries.dart`, including continent, languages (English, Spanish, Russian), currency (USD), timezone, and flag asset.

Versioning and documentation:

* Updated `pubspec.yaml` to version `1.2.2` to reflect the new release.
* Added a new entry in `CHANGELOG.md` documenting the addition of Antarctica.