### PR TITLE
feat: allow custom currency/country lists in picker icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.3
+- Added `currencies` parameter to `CurrencyWorldPickerIcon` to allow customizing the list of selectable currencies in the picker dialog.
+- Added `countries` parameter to `WorldPickerIcon` to allow customizing the list of selectable countries in the picker dialog.
+- Added `copyWith` method to the `Country` model.
+
 ## 1.3.2
 - Added Antarctica to the list of selectable countries.
 

--- a/lib/model/country_model.dart
+++ b/lib/model/country_model.dart
@@ -275,6 +275,32 @@ class Country {
   Currency? get primaryCurrency =>
       currencies.isNotEmpty ? currencies.first : null;
 
+  Country copyWith({
+    String? name,
+    String? isoCode,
+    Continent? continent,
+    List<Language>? languages,
+    List<Currency>? currencies,
+    String? dialCode,
+    String? phonePattern,
+    String? zipCodePattern,
+    List<String>? timezones,
+    String? flagAssetPath,
+  }) {
+    return Country(
+      name: name ?? this.name,
+      isoCode: isoCode ?? this.isoCode,
+      continent: continent ?? this.continent,
+      languages: languages ?? this.languages,
+      currencies: currencies ?? this.currencies,
+      dialCode: dialCode ?? this.dialCode,
+      phonePattern: phonePattern ?? this.phonePattern,
+      zipCodePattern: zipCodePattern ?? this.zipCodePattern,
+      timezones: timezones ?? this.timezones,
+      flagAssetPath: flagAssetPath ?? this.flagAssetPath,
+    );
+  }
+
   @override
   String toString() {
     return 'Country(name: $name, isoCode: $isoCode, continent: ${continent.name})';

--- a/lib/widgets/currency_world_picker_icon.dart
+++ b/lib/widgets/currency_world_picker_icon.dart
@@ -20,6 +20,7 @@ import 'package:world_picker/world_picker.dart';
 ///   selectedCountry: selectedCountry,
 ///   showIsoCode: true,
 ///   showDialCode: true,
+///   currencies: [Currency(code: 'USD', name: 'US Dollar', ...)],
 /// )
 /// ```
 class CurrencyWorldPickerIcon extends StatelessWidget {
@@ -51,6 +52,9 @@ class CurrencyWorldPickerIcon extends StatelessWidget {
   /// Configuration options for customizing the country picker dialog.
   final CurrencyWorldPickerOptions options;
 
+  /// A list of available currencies to display in the picker dialog.
+  final List<Currency> currencies;
+
   /// Creates a [WorldPickerIcon] widget.
   ///
   /// The [onSelect] callback is required and will be called when a user
@@ -66,6 +70,7 @@ class CurrencyWorldPickerIcon extends StatelessWidget {
     this.showDialCode = false,
     this.defaultCountryIsoCode = 'US',
     this.options = const CurrencyWorldPickerOptions(),
+    this.currencies = const [],
   });
 
   @override
@@ -135,7 +140,9 @@ class CurrencyWorldPickerIcon extends StatelessWidget {
           maxChildSize: 0.95,
           builder: (context, scrollController) {
             return CurrencyWorldPicker(
-              currencies: WorldPickerService.currencies(),
+              currencies: currencies.isNotEmpty
+                  ? currencies
+                  : WorldPickerService.currencies(),
               onSelect: (_) {
                 onSelect(_);
               },

--- a/lib/widgets/world_picker_icon.dart
+++ b/lib/widgets/world_picker_icon.dart
@@ -20,6 +20,7 @@ import 'package:world_picker/world_picker.dart';
 ///   selectedCountry: selectedCountry,
 ///   showIsoCode: true,
 ///   showDialCode: true,
+///   countries: [Country(isoCode: 'US', name: 'United States', ...)],
 /// )
 /// ```
 class WorldPickerIcon extends StatelessWidget {
@@ -51,6 +52,9 @@ class WorldPickerIcon extends StatelessWidget {
   /// Configuration options for customizing the country picker dialog.
   final WorldPickerOptions options;
 
+  /// A list of available countries to display in the picker dialog.
+  final List<Country> countries;
+
   /// Creates a [WorldPickerIcon] widget.
   ///
   /// The [onSelect] callback is required and will be called when a user
@@ -66,6 +70,7 @@ class WorldPickerIcon extends StatelessWidget {
     this.showDialCode = false,
     this.defaultCountryIsoCode = 'US',
     this.options = const WorldPickerOptions(),
+    this.countries = const [],
   });
 
   @override
@@ -166,7 +171,9 @@ class WorldPickerIcon extends StatelessWidget {
           builder: (context, scrollController) {
             return WorldPicker(
               key: Key('world_picker'),
-              countries: WorldPickerService.countries,
+              countries: countries.isNotEmpty
+                  ? countries
+                  : WorldPickerService.countries,
               size: size,
               onSelect: onSelect,
               options: options,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: world_picker
 description: Country selector and metadata provider with flags, currency, and more.
 
-version: 1.3.2
+version: 1.3.3
 
 homepage: https://github.com/williamsimionatto/world_picker
 repository: https://github.com/williamsimionatto/world_picker


### PR DESCRIPTION
Add optional currencies/countries params to CurrencyWorldPickerIcon and WorldPickerIcon so consumers can restrict the picker dialog's list instead of always using the full WorldPickerService data. Also adds Country.copyWith for consistency with Currency.