### PR TITLE
fix: filter CurrencyWorldPicker search against custom currency list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.4
+- Fixed `CurrencyWorldPicker` search filtering against the global currency list instead of the custom `currencies` list passed in.
+
 ## 1.3.3
 - Added `currencies` parameter to `CurrencyWorldPickerIcon` to allow customizing the list of selectable currencies in the picker dialog.
 - Added `countries` parameter to `WorldPickerIcon` to allow customizing the list of selectable countries in the picker dialog.

--- a/lib/widgets/currency_world_picker.dart
+++ b/lib/widgets/currency_world_picker.dart
@@ -74,15 +74,14 @@ class _CurrencyWorldPickerState extends State<CurrencyWorldPicker> {
   }
 
   void _filterCountries(String value) {
+    final query = value.toLowerCase();
     final filtered = value.isEmpty
         ? widget.currencies
-        : WorldPickerService.currencies(
-            code: value,
-            name: value,
-            symbol: value,
-          );
-
-    print(filtered);
+        : widget.currencies.where((currency) {
+            return currency.code.toLowerCase().contains(query) ||
+                currency.name.toLowerCase().contains(query) ||
+                currency.symbol.toLowerCase().contains(query);
+          }).toList();
 
     setState(() {
       _currencies = filtered;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: world_picker
 description: Country selector and metadata provider with flags, currency, and more.
 
-version: 1.3.3
+version: 1.3.4
 
 homepage: https://github.com/williamsimionatto/world_picker
 repository: https://github.com/williamsimionatto/world_picker


### PR DESCRIPTION
Search was querying WorldPickerService.currencies() (the global list) instead of filtering the currencies actually passed to the widget, so a custom currencies list was ignored once the user typed a query.